### PR TITLE
Remove minitest warning

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,6 @@ end
 require 'coveralls'
 Coveralls.wear!
 
-require 'minitest/spec'
 require 'minitest/autorun'
 
 


### PR DESCRIPTION
Warning: you should require 'minitest/autorun' instead.
