### PR TITLE
Remove ruby-head from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - jruby-19mode # JRuby in 1.9 mode
-  - ruby-head
   - jruby-head
   - rbx-19mode
   - 1.8.7
@@ -11,7 +10,6 @@ rvm:
   - jruby-18mode
 matrix:
   allow_failures:
-    - rvm: ruby-head
     - rvm: jruby-head
     - rvm: 1.8.7
     - rvm: rbx-18mode


### PR DESCRIPTION
"ruby-head" in travis is not ruby-head, behind from Ruby 2.0.0-p0 !
https://travis-ci.org/saturnflyer/casting/jobs/7683284

```
$ ruby --version
ruby 2.0.0dev (2012-12-12) [x86_64-linux]
```
