### PR TITLE
Look up the attendant only once

### DIFF
--- a/lib/casting/missing_method_client.rb
+++ b/lib/casting/missing_method_client.rb
@@ -45,8 +45,9 @@ module Casting
     end
 
     def method_missing(meth, *args, &block)
-      if !!method_delegate(meth)
-        delegate(meth, method_delegate(meth), *args, &block)
+      attendant = method_delegate(meth)
+      if !!attendant
+        delegate(meth, attendant, *args, &block)
       else
         super
       end

--- a/lib/casting/missing_method_client_class.rb
+++ b/lib/casting/missing_method_client_class.rb
@@ -13,8 +13,9 @@ module Casting
       end
 
       def method_missing(meth, *args, &block)
-        if !!method_class_delegate(meth)
-          delegate(meth, method_class_delegate(meth), *args, &block)
+        attendant = method_class_delegate(meth)
+        if !!attendant
+          delegate(meth, attendant, *args, &block)
         else
           super
         end


### PR DESCRIPTION
I see about a 20% improvement in the worst case.

``` ruby
require 'benchmark'
require 'casting'

module A; def does; end; end
module B; def other; end; end
module C; end

class Thing
  include Casting::Client
  delegate_missing_methods
end

def measure(bm, name, it)
  it.does
  bm.report(name) { 10_000.times { it.does } }
end

Benchmark.bm(3) do |bm|
  measure(bm, '1:', Thing.new.cast_as(A))
  measure(bm, '2:', Thing.new.cast_as(A).cast_as(B))
  measure(bm, '3:', Thing.new.cast_as(A).cast_as(B).cast_as(C))
end
```

```
fc810d9:
          user     system      total        real
1:    0.230000   0.000000   0.230000 (  0.232505)
2:    0.300000   0.000000   0.300000 (  0.293111)
3:    0.360000   0.000000   0.360000 (  0.363260)

835d320:
          user     system      total        real
1:    0.190000   0.000000   0.190000 (  0.188623)
2:    0.210000   0.000000   0.210000 (  0.212040)
3:    0.250000   0.000000   0.250000 (  0.248505)
```
