### PR TITLE
Test on Ruby 4.0 and clean up for latest standard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "3.3", "3.4"]
+        ruby: ["3.3", "3.4", "4.0"]
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v7

--- a/examples/dci.rb
+++ b/examples/dci.rb
@@ -11,6 +11,7 @@ end
 Account = Struct.new(:name, :balance)
 class Account
   include Casting::Client
+
   delegate_missing_methods
 
   alias_method :to_s, :name
@@ -59,7 +60,7 @@ class Funding
 
       self.balance += amount
 
-      if self.balance > 0
+      if balance > 0
         log("Funded #{self} with #{amount}")
       else
         self.balance -= amount

--- a/examples/delegation_dci.rb
+++ b/examples/delegation_dci.rb
@@ -26,6 +26,7 @@ savings = Account.new("~savings~", [2])
 # What it does
 class Transfer
   extend Casting::Context
+
   using Casting::Context
 
   initialize :amount, :source, :destination
@@ -54,7 +55,7 @@ class Transfer
       log("#{self} releasing #{role(:amount)} to #{role(:destination)}")
       tell :source, :check_balance
 
-      context.source = with(amounts: self.amounts << -role(:amount)).tap do |obj|
+      context.source = with(amounts: amounts << -role(:amount)).tap do |obj|
         log("#{self} released #{role(:amount)}. balance is now #{balance}")
       end
     end

--- a/examples/json-generator.rb
+++ b/examples/json-generator.rb
@@ -21,6 +21,7 @@ end
 
 class Jsoner
   include Casting::Client
+
   delegate_missing_methods
 
   def as_json(*attributes)

--- a/examples/roles_over_objects.rb
+++ b/examples/roles_over_objects.rb
@@ -4,6 +4,7 @@
 
 class User
   include Casting::Client
+
   delegate_missing_methods
 end
 

--- a/lib/casting/client.rb
+++ b/lib/casting/client.rb
@@ -20,27 +20,6 @@ module Casting
       end
     end
 
-    def delegation(delegated_method_name)
-      Casting::Delegation.prepare(delegated_method_name, self)
-    end
-
-    def cast(delegated_method_name, attendant, ...)
-      validate_attendant(attendant)
-      delegation(delegated_method_name).to(attendant).call(...)
-    end
-
-    def delegate_missing_methods(*which)
-      Casting::Client.set_delegation_strategy(singleton_class, *which.reverse)
-    end
-
-    private
-
-    def validate_attendant(attendant)
-      if attendant == self
-        raise Casting::InvalidAttendant.new("client can not delegate to itself")
-      end
-    end
-
     def self.set_delegation_strategy(base, *which)
       which = [:instance] if which.empty?
       which.map! { |selection|
@@ -60,6 +39,27 @@ module Casting
 
     def self.set_method_missing_client_class(base)
       base.send(:extend, ::Casting::MissingMethodClientClass)
+    end
+
+    def delegation(delegated_method_name)
+      Casting::Delegation.prepare(delegated_method_name, self)
+    end
+
+    def cast(delegated_method_name, attendant, ...)
+      validate_attendant(attendant)
+      delegation(delegated_method_name).to(attendant).call(...)
+    end
+
+    def delegate_missing_methods(*which)
+      Casting::Client.set_delegation_strategy(singleton_class, *which.reverse)
+    end
+
+    private
+
+    def validate_attendant(attendant)
+      if attendant == self
+        raise Casting::InvalidAttendant.new("client can not delegate to itself")
+      end
     end
   end
 end

--- a/lib/casting/context.rb
+++ b/lib/casting/context.rb
@@ -37,7 +37,7 @@ module Casting
       attr_reader(*setup_args)
       private(*setup_args)
 
-      define_method(:__custom_initialize, &(block || proc {}))
+      define_method(:__custom_initialize, &block || proc {})
 
       mod = Module.new
       mod.class_eval <<~INIT, __FILE__, __LINE__ + 1
@@ -99,7 +99,7 @@ module Casting
       # This role constant for special_person is SpecialPerson.
       def role_for(name)
         # Convert snake_case to CamelCase
-        role_name = name.to_s.split('_').map(&:capitalize).join
+        role_name = name.to_s.split("_").map(&:capitalize).join
         self.class.const_get(role_name)
       rescue NameError
         Module.new

--- a/lib/casting/delegation.rb
+++ b/lib/casting/delegation.rb
@@ -48,12 +48,11 @@ module Casting
       call_kwargs = keyword_arguments(kwargs)
       call_block = block_argument(&block)
 
-      case
-      when call_args && call_kwargs
+      if call_args && call_kwargs
         bound_method.call(*call_args, **call_kwargs, &call_block)
-      when call_args
+      elsif call_args
         bound_method.call(*call_args, &call_block)
-      when call_kwargs
+      elsif call_kwargs
         bound_method.call(**call_kwargs, &call_block)
       else
         bound_method.call(&call_block)

--- a/test/casting_enum_test.rb
+++ b/test/casting_enum_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class Person
   include Casting::Client
+
   delegate_missing_methods
 
   def initialize(name)

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -53,7 +53,7 @@ class BlockContext
   initialize :admin do
     @blocked = true
   end
-  attr :blocked
+  attr_reader :blocked
 end
 
 describe Casting::Context do

--- a/test/module_cleanup_test.rb
+++ b/test/module_cleanup_test.rb
@@ -16,6 +16,7 @@ end
 
 class CleanupPerson
   include Casting::Client
+
   delegate_missing_methods
   attr_accessor :name
 end


### PR DESCRIPTION
Verified the gem against the latest dependencies (incl. minitest 5→6) on Ruby 4.0.5; all 96 tests pass.

- CI matrix: 3.3, 3.4, 4.0 (drop 3.2)
- Fix new standardrb offenses; reorder `Client` class methods above `private`